### PR TITLE
fixing bug with platformio run compilation for iceprog (undefined loop functions)

### DIFF
--- a/programmer/olimexino-32u4 firmware/iceprog.ino
+++ b/programmer/olimexino-32u4 firmware/iceprog.ino
@@ -84,6 +84,9 @@ void startframe(uint8_t command);
 void addbyte(uint8_t newbyte);
 void readAllPages(void);
 void readpage(uint16_t adr);
+void loopProg(void);
+void loopBridge(void);
+
 
 // FRAME:   <FEND><CMD>{data if any}<FCS(sume of all bytes = 0xFF)><FEND>
 // if FEND, FESC in data - <FEND>=<FESC><TFEND>;  <FESC>=<FESC><TFESC>


### PR DESCRIPTION
```bash
$ platformio --version
PlatformIO Core, version 5.2.5

$ uname -a
Linux gm-laptop 5.11.0-38-generic #42~20.04.1-Ubuntu SMP Tue Sep 28 20:41:07 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
```

Bugfix for https://github.com/OLIMEX/iCE40HX1K-EVB/issues/12